### PR TITLE
Dockerize

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ import (
 type BurrowConfig struct {
 	General struct {
 		LogDir         string `gcfg:"logdir"`
+		PIDDir		   string `gcfg:"piddir"`
 		LogConfig      string `gcfg:"logconfig"`
 		PIDFile        string `gcfg:"pidfile"`
 		ClientID       string `gcfg:"client-id"`
@@ -112,6 +113,9 @@ func ValidateConfig(app *ApplicationContext) error {
 		if _, err := os.Stat(app.Config.General.LogConfig); os.IsNotExist(err) {
 			errs = append(errs, "Log configuration file does not exist")
 		}
+	}
+	if app.Config.General.PIDDir == "" {
+		app.Config.General.PIDDir = app.Config.General.LogDir
 	}
 	if app.Config.General.PIDFile == "" {
 		app.Config.General.PIDFile = "burrow.pid"

--- a/main.go
+++ b/main.go
@@ -111,8 +111,8 @@ func burrowMain() int {
 	}
 
 	// Create the PID file to lock out other processes. Defer removal so it's the last thing to go
-	createPidFile(appContext.Config.General.LogDir + "/" + appContext.Config.General.PIDFile)
-	defer removePidFile(appContext.Config.General.LogDir + "/" + appContext.Config.General.PIDFile)
+	createPidFile(appContext.Config.General.PIDDir + "/" + appContext.Config.General.PIDFile)
+	defer removePidFile(appContext.Config.General.PIDDir + "/" + appContext.Config.General.PIDFile)
 
 	// Set up stderr/stdout to go to a separate log file
 	openOutLog(appContext.Config.General.LogDir + "/burrow.out")


### PR DESCRIPTION
Allow specification of the burrow.pid directory. It is not convenient to have the pid file in the log directory when running burrow inside a container; unexpected crashes will forever fail to restart until that pid file is removed. Keeping the pid in a volume local to the container guarantees the pid file is clear on restart. 